### PR TITLE
Accept code 422 when registering host, which is thrown when host already exists.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
   apt_repository: repo="deb https://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" 
 
 - name: Installing Icinga packages.
-  apt: name="{{ item }}" state=latest
+  apt: name="{{ item }}" state=latest update_cache=yes
   notify: enable icinga
   with_items:
     - icinga2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,7 @@
 - name: Installing Icinga packages.
   apt: name="{{ item }}" state=latest
   notify: enable icinga
+  update_cache: "yes"
   with_items:
     - icinga2
     - monitoring-plugins

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     url: "{{ icinga_director_url }}/host"
     user: "{{ icinga_director_user }}"
     password: "{{ icinga_director_pass }}"
-    status_code: 201,500
+    status_code: 201,422,500
 
 - name: Trigger Icinga Director to deploy config.
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,6 @@
 - name: Installing Icinga packages.
   apt: name="{{ item }}" state=latest update_cache=yes
   notify: enable icinga
-  update_cache: "yes"
   with_items:
     - icinga2
     - monitoring-plugins


### PR DESCRIPTION
When running this playbook a second time, it fails because the host already exists.

This PR adds 422 as an acceptable status code which is what is thrown by icinga when a host exists.