### PR TITLE
Deprecation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This role requires Ansible 2.4 or higher. Requirements are listed in the metadat
 | `icinga_director_user` | Yes | `admin` | Icinga Web user for API authentication.  |
 | `icinga_director_pass` | Yes | Not set | Icinga Web user password for API authentication.  |
 | `icinga_director_host_protocol` | No | `http` | Protocol used to communicate with Icinga Director - http or https.  |
+| `icinga_register_client` | No | `yes` | Register Icinga client host. Set to `no` to skip this step. |
+| `icinga_deploy_config` | No | `yes` | Trigger Icinga Director to deploy config. Set to `no` to skip this step. | 
 
 
 Example Playbook
@@ -43,3 +45,4 @@ MIT
 Author Information
 ------------------
 This role was created in 2018 by [Mykhaylo Kolesnik](http://github.com/tenequm).
+Updates by [Blue Billywig](http://github.com/bluebillywig).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ icinga_client_host_object:
   object_type: "object"
   imports:
     - "{{ icinga_client_import_template }}"
+
+icinga_register_client: yes
+icinga_deploy_config: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,8 @@
     url: "{{ icinga_director_url }}/host"
     user: "{{ icinga_director_user }}"
     password: "{{ icinga_director_pass }}"
-    status_code: 201,500
+    status_code: 201,422,500
+  when: icinga_register_client
 
 - name: Trigger Icinga Director to deploy config.
   uri:
@@ -39,6 +40,7 @@
     url: "{{ icinga_director_url }}/config/deploy"
     user: "{{ icinga_director_user }}"
     password: "{{ icinga_director_pass }}"
+  when: icinga_deploy_config
 
 - name: Get Icinga client ticket.
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,12 @@
   apt_repository: repo="deb https://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" 
 
 - name: Installing Icinga packages.
-  apt: name="{{ item }}" state=latest
+  apt:
+    pkg:
+      - icinga2
+      - monitoring-plugins
+    state: latest
   notify: enable icinga
-  with_items:
-    - icinga2
-    - monitoring-plugins
 
 - name: Enable Icinga api feature.
   icinga2_feature: name=api


### PR DESCRIPTION
fix voor:

[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: ['icinga2', 'monitoring-plugins']` and remove the loop. This
feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

meer info: https://github.com/geerlingguy/ansible-role-docker/issues/77