### PR TITLE
Icinga cert fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This role requires Ansible 2.4 or higher. Requirements are listed in the metadat
 | `icinga_director_user` | Yes | `admin` | Icinga Web user for API authentication.  |
 | `icinga_director_pass` | Yes | Not set | Icinga Web user password for API authentication.  |
 | `icinga_director_host_protocol` | No | `http` | Protocol used to communicate with Icinga Director - http or https.  |
+| `icinga_register_client` | No | `yes` | Register Icinga client host. Set to `no` to skip this step. |
+| `icinga_deploy_config` | No | `yes` | Trigger Icinga Director to deploy config. Set to `no` to skip this step. | 
 
 
 Example Playbook
@@ -43,3 +45,4 @@ MIT
 Author Information
 ------------------
 This role was created in 2018 by [Mykhaylo Kolesnik](http://github.com/tenequm).
+Updates by [Blue Billywig](http://github.com/bluebillywig).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ icinga_client_host_object:
   object_type: "object"
   imports:
     - "{{ icinga_client_import_template }}"
+
+icinga_register_client: yes
+icinga_deploy_config: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
-- name: enable icinga
-  service: name=icinga2 state=started enabled=yes
+- name: restart icinga2
+  service:
+    name: icinga2
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,16 +67,16 @@
     - restart icinga2
   when: not key_exists.stat.exists
 
-- name: Check crt existance
+- name: Check master crt existance
   stat:
-    path: "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
-  register: crt_exists
+    path: "{{ icinga_client_certs_path }}trusted-master.crt"
+  register: master_crt_exists
 
 - name: Get master trusted cert.
   command: "icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt --trustedcert {{ icinga_client_certs_path }}trusted-master.crt --host {{ icinga_master_fqdn }}"
   notify:
     - restart icinga2
-  when: not crt_exists.stat.exists
+  when: not master_crt_exists.stat.exists
 
 - name: Check ca existance
   stat:
@@ -84,7 +84,7 @@
   register: ca_exists
 
 - name: Setup Icinga client node.
-  command: "icinga2 node setup --ticket {{ icinga_client_ticket.json }} --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} --trustedcert {{ icinga_client_certs_path }}trusted-master.crt --accept-commands --accept-config"
+  command: "icinga2 node setup --ticket {{ icinga_client_ticket.json }} --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} --zone {{ icinga_client_fqdn }} --parent_host {{ icinga_master_fqdn }} --trustedcert {{ icinga_client_certs_path }}trusted-master.crt --accept-commands --accept-config"
   notify:
     - restart icinga2
   when: not ca_exists.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,11 @@
   apt_repository: repo="deb https://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" 
 
 - name: Installing Icinga packages.
-  apt: name="{{ item }}" state=latest
-  notify: enable icinga
-  with_items:
-    - icinga2
-    - monitoring-plugins
+  apt:
+    pkg:
+      - icinga2
+      - monitoring-plugins
+    state: latest
 
 - name: Enable Icinga api feature.
   icinga2_feature: name=api
@@ -58,7 +58,14 @@
   notify:
     - restart icinga2
 
-- name: Generate Icinga client certs.
+- nt Icinga client ticket.
+  uri:
+    headers:
+      Accept: application/json
+    url: "{{ icinga_director_url }}/host/ticket?name={{ icinga_client_fqdn }}"
+    user: "{{ icinga_director_user }}"
+    password: "{{ icinga_director_pass }}"
+    return_content: yesame: Generate Icinga client certs.
   command: >
     icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,8 +63,8 @@
 
 - name: Generate Icinga client certs.
   command: "icinga2 pki new-cert --cn {{ icinga_client_fqdn }} --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
-    notify:
-      - restart icinga2
+  notify:
+    - restart icinga2
   when: not key_exists.stat.exists
 
 - name: Check crt existance
@@ -74,8 +74,8 @@
 
 - name: Get master trusted cert.
   command: "icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt --trustedcert {{ icinga_client_certs_path }}trusted-master.crt --host {{ icinga_master_fqdn }}"
-    notify:
-      - restart icinga2
+  notify:
+    - restart icinga2
   when: not crt_exists.stat.exists
 
 - name: Check ca existance
@@ -85,8 +85,8 @@
 
 - name: Setup Icinga client node.
   command: "icinga2 node setup --ticket {{ icinga_client_ticket.json }} --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} --trustedcert {{ icinga_client_certs_path }}trusted-master.crt --accept-commands --accept-config"
-    notify:
-      - restart icinga2
+  notify:
+    - restart icinga2
   when: not ca_exists.stat.exists
 
 - name: Ensure default 'conf.d' directory is not used.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
     password: "{{ icinga_director_pass }}"
     return_content: yes
   register: icinga_client_ticket
-  creates: {{ icinga_client_certs_path }}ca.crt
+  creates: "{{ icinga_client_certs_path }}ca.crt"
   notify:
     - restart icinga2
 
@@ -69,7 +69,7 @@
     icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
-  creates: {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key
+  creates: "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.key"
   notify:
     - restart icinga2
 
@@ -79,7 +79,7 @@
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --host {{ icinga_master_fqdn }}
-  creates: {{ icinga_client_certs_path }}trusted-master.crt
+  creates: "{{ icinga_client_certs_path }}trusted-master.crt"
   notify:
     - restart icinga2
 
@@ -90,7 +90,7 @@
     --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --accept-commands --accept-config
-  creates: {{ icinga_client_certs_path }}ca.crt
+  creates: "{{ icinga_client_certs_path }}ca.crt"
   notify:
     - restart icinga2
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,8 @@
 
 - name: Ensure 'certs' directory exists.
   file: path={{ icinga_client_certs_path }} state=directory owner=nagios group=nagios 
+  notify:
+    - restart icinga2
 
 - name: Register Icinga client host.
   uri:
@@ -51,13 +53,21 @@
     password: "{{ icinga_director_pass }}"
     return_content: yes
   register: icinga_client_ticket
+  creates:
+    - {{ icinga_client_certs_path }}ca.crt
+  notify:
+    - restart icinga2
 
 - name: Generate Icinga client certs.
   command: >
     icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
-  changed_when: false
+  creates:
+    - {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key
+    - {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
+  notify:
+    - restart icinga2
 
 - name: Get master trusted cert.
   command: >
@@ -65,7 +75,10 @@
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --host {{ icinga_master_fqdn }}
-  changed_when: false
+  creates:
+    - {{ icinga_client_certs_path }}trusted-master.crt
+  notify:
+    - restart icinga2
 
 - name: Setup Icinga client node.
   command: >
@@ -74,7 +87,10 @@
     --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --accept-commands --accept-config
-  changed_when: false
+  creates:
+    - {{ icinga_client_certs_path }}ca.crt
+  notify:
+    - restart icinga2
 
 - name: Ensure default 'conf.d' directory is not used.
   lineinfile: 
@@ -82,6 +98,12 @@
     regexp: 'include_recursive.*conf\.d'
     line: '//include_recursive "conf.d"'
 
-- name: Restart Icinga service.
-  service: name=icinga2 state=restarted
-  changed_when: false
+- name: ensure icinga2 is running
+  service:
+    name: icinga2
+    state: started
+handlers:
+  - name: restart icinga2
+    service:
+      name: icinga2
+      state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,14 +56,24 @@
   notify:
     - restart icinga2
 
+- name: Check key existance
+  stat:
+    path: {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key
+  register: key_exists
+
 - name: Generate Icinga client certs.
   command: >
     cmd: icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
-    creates: "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.key"
     notify:
       - restart icinga2
+  when: not key_exists.stat.exists
+
+- name: Check crt existance
+  stat:
+    path: {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
+  register: crt_exists
 
 - name: Get master trusted cert.
   command: >
@@ -71,9 +81,14 @@
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --host {{ icinga_master_fqdn }}
-    creates: "{{ icinga_client_certs_path }}trusted-master.crt"
     notify:
       - restart icinga2
+  when: not crt_exists.stat.exists
+
+- name: Check ca existance
+  stat:
+    path: {{ icinga_client_certs_path }}ca.crt
+  register: ca_exists
 
 - name: Setup Icinga client node.
   command: >
@@ -82,9 +97,9 @@
     --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --accept-commands --accept-config
-    creates: "{{ icinga_client_certs_path }}ca.crt"
     notify:
       - restart icinga2
+  when: not ca_exists.stat.exists
 
 - name: Ensure default 'conf.d' directory is not used.
   lineinfile: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,8 +53,7 @@
     password: "{{ icinga_director_pass }}"
     return_content: yes
   register: icinga_client_ticket
-  creates:
-    - "{{ icinga_client_certs_path }}ca.crt"
+  creates: {{ icinga_client_certs_path }}ca.crt
   notify:
     - restart icinga2
 
@@ -70,9 +69,7 @@
     icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
-  creates:
-    - "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.key"
-    - "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
+  creates: {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key
   notify:
     - restart icinga2
 
@@ -82,8 +79,7 @@
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --host {{ icinga_master_fqdn }}
-  creates:
-    - "{{ icinga_client_certs_path }}trusted-master.crt"
+  creates: {{ icinga_client_certs_path }}trusted-master.crt
   notify:
     - restart icinga2
 
@@ -94,8 +90,7 @@
     --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --accept-commands --accept-config
-  creates:
-    - "{{ icinga_client_certs_path }}ca.crt"
+  creates: {{ icinga_client_certs_path }}ca.crt
   notify:
     - restart icinga2
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,8 @@
     url: "{{ icinga_director_url }}/host"
     user: "{{ icinga_director_user }}"
     password: "{{ icinga_director_pass }}"
-    status_code: 201,500
+    status_code: 201,422,500
+  when: icinga_register_client
 
 - name: Trigger Icinga Director to deploy config.
   uri:
@@ -39,6 +40,7 @@
     url: "{{ icinga_director_url }}/config/deploy"
     user: "{{ icinga_director_user }}"
     password: "{{ icinga_director_pass }}"
+  when: icinga_deploy_config
 
 - name: Get Icinga client ticket.
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,10 +62,7 @@
   register: key_exists
 
 - name: Generate Icinga client certs.
-  command: >
-    "icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
-    --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
-    --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
+  command: "icinga2 pki new-cert --cn {{ icinga_client_fqdn }} --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
     notify:
       - restart icinga2
   when: not key_exists.stat.exists
@@ -76,11 +73,7 @@
   register: crt_exists
 
 - name: Get master trusted cert.
-  command: >
-    "icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
-    --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
-    --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
-    --host {{ icinga_master_fqdn }}"
+  command: "icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt --trustedcert {{ icinga_client_certs_path }}trusted-master.crt --host {{ icinga_master_fqdn }}"
     notify:
       - restart icinga2
   when: not crt_exists.stat.exists
@@ -91,12 +84,7 @@
   register: ca_exists
 
 - name: Setup Icinga client node.
-  command: >
-    "icinga2 node setup --ticket {{ icinga_client_ticket.json }} \
-    --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} \
-    --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
-    --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
-    --accept-commands --accept-config"
+  command: "icinga2 node setup --ticket {{ icinga_client_ticket.json }} --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} --trustedcert {{ icinga_client_certs_path }}trusted-master.crt --accept-commands --accept-config"
     notify:
       - restart icinga2
   when: not ca_exists.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,6 @@
     password: "{{ icinga_director_pass }}"
     return_content: yes
   register: icinga_client_ticket
-  creates: "{{ icinga_client_certs_path }}ca.crt"
   notify:
     - restart icinga2
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,7 +63,7 @@
 
 - name: Generate Icinga client certs.
   command: >
-    cmd: icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
+    icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
     notify:
@@ -77,7 +77,7 @@
 
 - name: Get master trusted cert.
   command: >
-    cmd: icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
+    icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --host {{ icinga_master_fqdn }}
@@ -92,7 +92,7 @@
 
 - name: Setup Icinga client node.
   command: >
-    cmd: icinga2 node setup --ticket {{ icinga_client_ticket.json }} \
+    icinga2 node setup --ticket {{ icinga_client_ticket.json }} \
     --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} \
     --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,9 +63,9 @@
 
 - name: Generate Icinga client certs.
   command: >
-    icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
+    "icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
-    --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
+    --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
     notify:
       - restart icinga2
   when: not key_exists.stat.exists
@@ -77,10 +77,10 @@
 
 - name: Get master trusted cert.
   command: >
-    icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
+    "icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
-    --host {{ icinga_master_fqdn }}
+    --host {{ icinga_master_fqdn }}"
     notify:
       - restart icinga2
   when: not crt_exists.stat.exists
@@ -92,11 +92,11 @@
 
 - name: Setup Icinga client node.
   command: >
-    icinga2 node setup --ticket {{ icinga_client_ticket.json }} \
+    "icinga2 node setup --ticket {{ icinga_client_ticket.json }} \
     --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} \
     --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
-    --accept-commands --accept-config
+    --accept-commands --accept-config"
     notify:
       - restart icinga2
   when: not ca_exists.stat.exists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
 
 - name: Check key existance
   stat:
-    path: {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key
+    path: "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.key"
   register: key_exists
 
 - name: Generate Icinga client certs.
@@ -72,7 +72,7 @@
 
 - name: Check crt existance
   stat:
-    path: {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
+    path: "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
   register: crt_exists
 
 - name: Get master trusted cert.
@@ -87,7 +87,7 @@
 
 - name: Check ca existance
   stat:
-    path: {{ icinga_client_certs_path }}ca.crt
+    path: "{{ icinga_client_certs_path }}ca.crt"
   register: ca_exists
 
 - name: Setup Icinga client node.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -97,8 +97,3 @@
   service:
     name: icinga2
     state: started
-handlers:
-  - name: restart icinga2
-    service:
-      name: icinga2
-      state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,7 @@
     return_content: yes
   register: icinga_client_ticket
   creates:
-    - {{ icinga_client_certs_path }}ca.crt
+    - "{{ icinga_client_certs_path }}ca.crt"
   notify:
     - restart icinga2
 
@@ -71,8 +71,8 @@
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
   creates:
-    - {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key
-    - {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
+    - "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.key"
+    - "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt"
   notify:
     - restart icinga2
 
@@ -83,7 +83,7 @@
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --host {{ icinga_master_fqdn }}
   creates:
-    - {{ icinga_client_certs_path }}trusted-master.crt
+    - "{{ icinga_client_certs_path }}trusted-master.crt"
   notify:
     - restart icinga2
 
@@ -95,7 +95,7 @@
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --accept-commands --accept-config
   creates:
-    - {{ icinga_client_certs_path }}ca.crt
+    - "{{ icinga_client_certs_path }}ca.crt"
   notify:
     - restart icinga2
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,33 +58,33 @@
 
 - name: Generate Icinga client certs.
   command: >
-    icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
+    cmd: icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt
-  creates: "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.key"
-  notify:
-    - restart icinga2
+    creates: "{{ icinga_client_certs_path ~ icinga_client_fqdn }}.key"
+    notify:
+      - restart icinga2
 
 - name: Get master trusted cert.
   command: >
-    icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
+    cmd: icinga2 pki save-cert --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \
     --cert {{ icinga_client_certs_path ~ icinga_client_fqdn }}.crt \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --host {{ icinga_master_fqdn }}
-  creates: "{{ icinga_client_certs_path }}trusted-master.crt"
-  notify:
-    - restart icinga2
+    creates: "{{ icinga_client_certs_path }}trusted-master.crt"
+    notify:
+      - restart icinga2
 
 - name: Setup Icinga client node.
   command: >
-    icinga2 node setup --ticket {{ icinga_client_ticket.json }} \
+    cmd: icinga2 node setup --ticket {{ icinga_client_ticket.json }} \
     --cn {{ icinga_client_fqdn }} --endpoint {{ icinga_master_endpoint }} \
     --zone {{ icinga_client_fqdn }} --master_host {{ icinga_master_fqdn }} \
     --trustedcert {{ icinga_client_certs_path }}trusted-master.crt \
     --accept-commands --accept-config
-  creates: "{{ icinga_client_certs_path }}ca.crt"
-  notify:
-    - restart icinga2
+    creates: "{{ icinga_client_certs_path }}ca.crt"
+    notify:
+      - restart icinga2
 
 - name: Ensure default 'conf.d' directory is not used.
   lineinfile: 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,14 +57,7 @@
   notify:
     - restart icinga2
 
-- nt Icinga client ticket.
-  uri:
-    headers:
-      Accept: application/json
-    url: "{{ icinga_director_url }}/host/ticket?name={{ icinga_client_fqdn }}"
-    user: "{{ icinga_director_user }}"
-    password: "{{ icinga_director_pass }}"
-    return_content: yesame: Generate Icinga client certs.
+- name: Generate Icinga client certs.
   command: >
     icinga2 pki new-cert --cn {{ icinga_client_fqdn }} \
     --key {{ icinga_client_certs_path ~ icinga_client_fqdn }}.key \


### PR DESCRIPTION
Dit werkt eindelijk :) 

Wat is er allemaal gedaan:

- installatie van packages via apt gaat nu zonder gebruik te maken van een deprecated structure.
- cert / register commando's en service restarts gebeuren alleen als het echt nodig is.